### PR TITLE
Fix ts to colcon build by describing the order

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ cd .. && rm -rf  rostmsdb_collections
 ```
 cd
 wget https://github.com/mongodb/mongo-c-driver/releases/download/1.24.4/mongo-c-driver-1.24.4.tar.gz
+tar -xzf mongo-c-driver-1.24.4.tar.gz
 cd mongo-c-driver-1.24.4
 mkdir cmake-build
 cd cmake-build

--- a/tms_sp/tms_sp_machine/package.xml
+++ b/tms_sp/tms_sp_machine/package.xml
@@ -21,6 +21,8 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>rclpy</build_depend>
 
+  <build_depend>tms_msg_db</build_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/tms_ts/tms_ts_manager/package.xml
+++ b/tms_ts/tms_ts_manager/package.xml
@@ -8,6 +8,7 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>tms_ts_subtask</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
- [ ] Fix the lack of tar command to open `mongo-c-driver-1.24.4.tar.gz`.
- [ ] Describe dependencies in `package.xml` to build appropriate order.