### PR TITLE
Fix setup.sh

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,3 +1,4 @@
 *.db3-shm
 *.db3-wal
 rostmsdb_collections
+dump

--- a/setup.sh
+++ b/setup.sh
@@ -37,9 +37,6 @@ sudo apt install -y ros-humble-desktop
 sudo apt install -y ros-humble-ros-base
 sudo apt install -y ros-dev-tools
 
-sudo pip install pymongo
-
-
 echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 source /opt/ros/humble/setup.bash
 

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,6 @@ sudo apt install -y ros-humble-desktop
 sudo apt install -y ros-humble-ros-base
 sudo apt install -y ros-dev-tools
 
-sudo apt install pip
 sudo pip install pymongo
 
 
@@ -66,8 +65,8 @@ wget https://downloads.mongodb.com/compass/mongodb-compass_1.43.0_amd64.deb
 sudo dpkg -i mongodb-compass_1.43.0_amd64.deb
 rm mongodb-compass_1.43.0_amd64.deb
 
-
 # install required python packages
+sudo apt install -y pip
 cd ~/ros2-tms-for-construction_ws/src/ros2_tms_for_construction
 python3 -m pip install -r requirements.txt --quiet --no-input
 

--- a/setup.sh
+++ b/setup.sh
@@ -110,7 +110,7 @@ cd ~/ros2-tms-for-construction_ws/src && git clone https://github.com/BehaviorTr
 cd .. && colcon build --packages-select groot
 
 #Install nlohmann-json library
-sudo apt install nlohmann-json3-dev
+sudo apt install -y nlohmann-json3-dev
 
 #Setup OPERA
 # Install dbcppp

--- a/setup.sh
+++ b/setup.sh
@@ -64,6 +64,7 @@ echo "mongodb-org-tools hold" | sudo dpkg --set-selections
 #MongoDB Compass
 wget https://downloads.mongodb.com/compass/mongodb-compass_1.43.0_amd64.deb
 sudo dpkg -i mongodb-compass_1.43.0_amd64.deb
+rm mongodb-compass_1.43.0_amd64.deb
 
 
 # install required python packages

--- a/setup.sh
+++ b/setup.sh
@@ -34,8 +34,6 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-a
 sudo apt update
 sudo apt -y upgrade
 sudo apt install -y ros-humble-desktop
-sudo apt install -y ros-humble-ros-base
-sudo apt install -y ros-dev-tools
 
 echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
 source /opt/ros/humble/setup.bash


### PR DESCRIPTION
少し直しました。認識が誤っているところなどあればコメントください。

- `demo/dump`がgit追跡されていたため、gitignoreに追加しました。
- `mongodb-compass_1.43.0_amd64.deb`もgit追跡されましたが、これはインストーラーであると考えたため`rm`するスクリプトを足しました。
- `ros-humble-ros-base`と`ros-dev-tools`は`ros-humble-desktop`に含まれているという認識です。
- `pip`のインストール位置をPythonのところに持っていきました。
