### PR TITLE
feat(docker): X11 ベースの開発用 Docker 環境を docker/ 配下に追加

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,119 @@
+# syntax=docker/dockerfile:1.6
+#
+# ros2_tms_for_construction — X11 + MongoDB-separated dev image
+#
+# Base : osrf/ros:humble-desktop-full (Ubuntu 22.04 jammy)
+# GUI  : X11 forward (no VNC)
+# DB   : provided by separate `mongodb` service in compose.yaml
+#
+# Build context expected at the repository root (../). This Dockerfile is
+# referenced as `dockerfile: docker/Dockerfile` from `docker/compose.yaml`.
+
+FROM osrf/ros:humble-desktop-full
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USERNAME=ros
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# ---------------------------------------------------------------------------
+# 1. APT dependencies
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake git curl wget gnupg ca-certificates pkg-config \
+        unzip xvfb gosu \
+        python3-pip python3-vcstool python3-colcon-common-extensions \
+        libzmq3-dev libboost-dev libncurses5-dev libncursesw5-dev libssl-dev \
+        nlohmann-json3-dev rapidjson-dev \
+        qtbase5-dev libqt5svg5-dev libdw-dev \
+        ros-humble-robot-localization \
+    && apt-get install -y --no-install-recommends \
+        'ros-humble-*moveit*' \
+        'ros-humble-*nav2*' \
+        'ros-humble-*tf*' \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 2. MongoDB database tools (mongorestore / mongodump for `restore-db.sh`)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc \
+      | gpg -o /usr/share/keyrings/mongodb-server-6.0.gpg --dearmor \
+    && echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-6.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" \
+      > /etc/apt/sources.list.d/mongodb-org-6.0.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends mongodb-database-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 3. BehaviorTree.CPP v3.8 (source build → /usr/local)
+# ---------------------------------------------------------------------------
+RUN cd /tmp \
+    && git clone --depth 1 --branch v3.8 https://github.com/BehaviorTree/BehaviorTree.CPP.git \
+    && cmake -S BehaviorTree.CPP -B BehaviorTree.CPP/build -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build BehaviorTree.CPP/build -j"$(nproc)" --target install \
+    && rm -rf BehaviorTree.CPP
+
+# ---------------------------------------------------------------------------
+# 4. mongo-c-driver 1.24.4 + mongo-cxx-driver r3.8.1 (source build → /usr/local)
+# ---------------------------------------------------------------------------
+RUN cd /tmp \
+    && wget -q https://github.com/mongodb/mongo-c-driver/releases/download/1.24.4/mongo-c-driver-1.24.4.tar.gz \
+    && tar -xzf mongo-c-driver-1.24.4.tar.gz \
+    && cmake -S mongo-c-driver-1.24.4 -B mongo-c-driver-1.24.4/build \
+        -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build mongo-c-driver-1.24.4/build -j"$(nproc)" --target install \
+    && rm -rf mongo-c-driver-1.24.4*
+
+RUN cd /tmp \
+    && wget -q https://github.com/mongodb/mongo-cxx-driver/releases/download/r3.8.1/mongo-cxx-driver-r3.8.1.tar.gz \
+    && tar -xzf mongo-cxx-driver-r3.8.1.tar.gz \
+    && cmake -S mongo-cxx-driver-r3.8.1 -B mongo-cxx-driver-r3.8.1/build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBSONCXX_POLY_USE_BOOST=1 \
+        -DMONGOCXX_OVERRIDE_DEFAULT_INSTALL_PREFIX=OFF \
+    && cmake --build mongo-cxx-driver-r3.8.1/build -j"$(nproc)" --target install \
+    && rm -rf mongo-cxx-driver-r3.8.1*
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+
+# ---------------------------------------------------------------------------
+# 5. Python dependencies
+#    Placed after the heavy C++ source builds so changes to requirements.txt
+#    do not invalidate those cache layers.
+# ---------------------------------------------------------------------------
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# ---------------------------------------------------------------------------
+# 6. External ROS 2 packages via vcstool
+#    (cloned into /workspace/src/, built at first container run)
+# ---------------------------------------------------------------------------
+RUN mkdir -p /workspace/src
+COPY docker/src.repos /tmp/src.repos
+RUN cd /workspace/src && vcs import < /tmp/src.repos && rm /tmp/src.repos
+
+# ---------------------------------------------------------------------------
+# 7. Non-root user matching host UID/GID for X11 + bind-mount permissions.
+#    User creation only — privileges are dropped at runtime via `gosu` inside
+#    entrypoint.sh. No sudoers NOPASSWD is granted.
+# ---------------------------------------------------------------------------
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m -s /bin/bash ${USERNAME} \
+    && mkdir -p /workspace/build /workspace/install /workspace/log \
+    && chown -R ${USERNAME}:${USERNAME} /workspace
+
+RUN echo 'source /opt/ros/humble/setup.bash' >> /home/${USERNAME}/.bashrc \
+    && echo '[ -f /workspace/install/setup.bash ] && source /workspace/install/setup.bash' >> /home/${USERNAME}/.bashrc \
+    && echo 'export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}' >> /home/${USERNAME}/.bashrc
+
+# Container starts as root so entrypoint.sh can chown the named volumes on
+# first mount; it then drops to `${USERNAME}` via gosu before exec'ing CMD.
+WORKDIR /workspace
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,14 @@
+# Per-Dockerfile ignore file (Docker 20.10+ with BuildKit). Scoped to
+# docker/Dockerfile only — the rest of the repo is unaffected.
+#
+# Build context is the repository root (compose.yaml sets `context: ..`).
+# This Dockerfile only COPYs:
+#   - requirements.txt           (from repo root)
+#   - docker/src.repos
+#   - docker/entrypoint.sh
+# so we use an allowlist to keep the build context tiny (host repo root is
+# dominated by demo/ and .git/, both ~250 MB).
+*
+!requirements.txt
+!docker/src.repos
+!docker/entrypoint.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,20 +76,46 @@ docker exec -it -u ros -e DISPLAY=$DISPLAY ros2_tms_dev bash
 
 `-u ros` は必須（コンテナの `USER` が root のまま、entrypoint 内で `gosu` drop しているため）。
 
-### Step A. 4 ターミナル起動（順序任意）
+### Step A. 2 ターミナル起動
 
-各ターミナルで前置きの `docker exec ...` を実行してから以下を起動する。
+各ターミナルで前置きの `docker exec ...` を実行してから以下を起動する。**Terminal 1 を起動して Unity を再生したあとに Terminal 2 を起動する** 順序を守ること（理由は後述）。
 
 | Terminal | 役割 | コマンド |
 |---|---|---|
 | 1 | Unity ↔ ROS 2 ブリッジ | `ros2 launch ros_tcp_endpoint endpoint.py` |
-| 2 | tms_if_for_opera アクションサーバ群 | `ros2 launch tms_if_for_opera tms_if_for_opera.launch.py` |
-| 3 | zx200 MoveIt2 + ros2_control + RViz | `ros2 launch zx200_bringup vehicle.launch.py use_rviz:=true command_interface_name:=velocity` |
-| 4 | task scheduler + zx200 subtask 群 + `tms_ur_button` GUI | `ros2 launch tms_ts_launch tms_ts_construction.launch.py task_id:=4` |
+| 2 | zx200 MoveIt2 + RViz / `tms_if_for_opera` / `tms_ts_construction` を順次起動 | `ros2 launch /workspace/src/ros2_tms_for_construction/docker/launch/bringup.launch.yaml` |
 
-Terminal 3 の `command_interface_name:=velocity` は Unity 側で `boom_link` / `arm_link` / `bucket_link` の Control Type を Velocity に設定する Step B と整合させるため。`use_rviz:=true` で MoveIt2 用 RViz が起動する。
+Terminal 2 で起動する `bringup.launch.yaml` は内部で 3 つの launch ファイルを timer 付きで連鎖起動する:
 
-Terminal 3 までの起動状態で、RViz の MotionPlanning パネルから手動 Plan & Execute も可能（BT を使わない動作確認）。
+1. **t = 0 s** — `zx200_bringup vehicle.launch.py`（`command_interface_name:=velocity`、`use_rviz:=true` がデフォルト）
+2. **t = `tms_if_delay` s（既定 5）** — `tms_if_for_opera tms_if_for_opera.launch.py`
+3. **t = `tms_ts_delay` s（既定 10）** — `tms_ts_launch tms_ts_construction.launch.py`（`task_id:=4` がデフォルト）
+
+時間差を入れているのは `zx200_bringup` が `robot_description_semantic` (SRDF) を publish する前に `tms_if_for_opera` 側の MoveGroupInterface が subscribe すると 10 秒タイムアウトで FATAL 終了するため。低性能ホストで FATAL が出る場合は後述の `tms_if_delay` / `tms_ts_delay` を増やす。
+
+Terminal 1 を先に起動する理由: Unity 側の `JointStatePublisher` が `/zx200/joint_states` を publish する前に `zx200_bringup` の `ros2_control` を起動すると、初期姿勢を取得できずコントローラ初期化が不安定になる。Terminal 1 の `ros_tcp_endpoint` を立ててから Step B で Unity を再生し、joint_states が流れ始めてから Terminal 2 を起動する。
+
+利用可能な引数（任意）:
+
+| 引数 | デフォルト | 説明 |
+|---|---|---|
+| `task_id` | `4` | 緑ボタンで実行する BT の task_id |
+| `command_interface_name` | `velocity` | ros2_control の command interface (`velocity` / `position` / `effort`) |
+| `use_rviz` | `true` | `zx200_bringup` の RViz を起動するか |
+| `tms_if_delay` | `5.0` | `tms_if_for_opera` 起動までの待ち時間（秒）。SRDF の subscribe timeout 回避用 |
+| `tms_ts_delay` | `10.0` | `tms_ts_construction` 起動までの待ち時間（秒）。`tms_if_delay` より大きく |
+
+例:
+
+```bash
+# 別の task を試す
+ros2 launch <…>/bringup.launch.yaml task_id:=5
+
+# 低性能ホストで SRDF subscribe timeout が出る場合は遅延を伸ばす
+ros2 launch <…>/bringup.launch.yaml tms_if_delay:=8 tms_ts_delay:=14
+```
+
+Terminal 2 起動後（`tms_ts_delay` 経過以降）、緑ボタンを押す前に RViz の MotionPlanning パネルから手動 Plan & Execute も可能（BT を使わない動作確認）。
 
 ### Step B. Unity 側の設定（初回のみ）と再生
 
@@ -102,7 +128,7 @@ ROS-TCP-Endpoint (Terminal 1) が listen 状態になってから Unity を再�
 
 ### Step C. RViz で初期姿勢を回避（衝突回避の前処理）
 
-Terminal 3 で起動した RViz2 の MoveIt パネルを操作する。
+Terminal 2 で起動した RViz2 の MoveIt パネルを操作する。
 
 起動直後はバックホウのアームが伸び切った姿勢で、バケットが地面に接触している（バケットが**ピンク色**で表示される＝衝突状態）。この状態のまま緑ボタンを押すと BT 実行中に planning が破綻し表示が崩れるため、**先に手動で 1 回だけ姿勢を正しておく**:
 
@@ -111,13 +137,13 @@ Terminal 3 で起動した RViz2 の MoveIt パネルを操作する。
 3. **`Planning` タブ → `Plan and Execute`** で実行
 4. バケットがピンク色でなくなったことを確認
 
-Terminal 4 を起動するたびに必要（停止 → 再起動でこの状態に戻る）。
+Terminal 2 を起動するたびに必要（停止 → 再起動でこの状態に戻る）。
 
 ### Step D. `tms_ur_button` GUI の緑ボタンで BT 実行
 
-Terminal 4 起動時に `tms_ur_button` が Tkinter のウィンドウを表示する。緑ボタンを押すと task_id=4 の Behavior Tree が `task_schedular_manager` に送られ、Unity 上のバックホウが掘削動作する。
+Terminal 2 起動から `tms_ts_delay` 秒（既定 10）経過後、`tms_ts_construction` 側の `tms_ur_button` が Tkinter のウィンドウを表示する。緑ボタンを押すと `task_id`（デフォルト `4`）の Behavior Tree が `task_schedular_manager` に送られ、Unity 上のバックホウが掘削動作する。
 
-1 回の実行で BT 全体が SUCCESS して終端する設計のため、**もう一度動かしたい場合は Terminal 4 を Ctrl-C → 再起動** してから Step C → 緑ボタンを押す（または BT 自体を `Repeat num_cycles=N` 構造で登録し直す。シードの `task_id=5` は task_id=4 を 4 回反復する版）。
+1 回の実行で BT 全体が SUCCESS して終端する設計のため、**もう一度動かしたい場合は Terminal 2 を Ctrl-C → 再起動** してから Step C → 緑ボタンを押す（または BT 自体を `Repeat num_cycles=N` 構造で登録し直す。シードの `task_id=5` は task_id=4 を 4 回反復する版）。
 
 ## 停止
 
@@ -142,7 +168,8 @@ docker compose down -v      # named volume ごと削除（DB・build キャッ�
 |---|---|
 | `Dockerfile` | ベース image + ROS 2 依存 + source build で BehaviorTree.CPP / mongocxx / mongo-c-driver + `vcs import` |
 | `Dockerfile.dockerignore` | このビルド専用の ignore ファイル（BuildKit の per-Dockerfile ignore）。allowlist 形式でビルドコンテキストを絞る |
-| `compose.yaml` | `mongodb`（`mongo:6.0`）と `tms` の 2 サービス、named volume、X11 forward、`network_mode: host` |
+| `compose.yaml` | `mongodb`（`mongo:6.0`）と `tms` の 2 サービス、named volume、X11 forward、`network_mode: host`、`tms` には Fast DDS の SHM lock 用に `shm_size: 1g` を割当 |
 | `entrypoint.sh` | root で named volume 所有権を修正後、`gosu` で `ros` に drop。成功 sentinel で初回 `colcon build` を一度だけ実行 |
 | `restore-db.sh` | `demo/rostmsdb_collections.zip` を展開して `mongorestore`、その後 `parameter` collection から `description` (string) フィールドを除去（subtask が数値型のみ対応のため） |
 | `src.repos` | vcstool 管理。外部 repo を 40 桁 full commit SHA で pin（コメントで元ブランチと日付を保持） |
+| `launch/bringup.launch.yaml` | Terminal 2 用。`zx200_bringup` → 8 s → `tms_if_for_opera` → 14 s → `tms_ts_construction` の 3 launch を timer 連鎖起動する YAML launch |

--- a/docker/README.md
+++ b/docker/README.md
@@ -158,6 +158,7 @@ docker compose down -v      # named volume ごと削除（DB・build キャッ�
 - GPU アクセラレーションは未設定（必要なら `compose.yaml` に `deploy.resources.reservations.devices` を追加）。
 - `*moveit*` / `*nav2*` / `*tf*` をワイルドカードで apt install しているため image サイズが大きい（約 12 GB）。必要パッケージに絞るには Dockerfile を調整する。
 - **ポート衝突**: `network_mode: host` のため `27017`（MongoDB）および Terminal 1 で使う `10000`（ros_tcp_endpoint）がホストで使用中だと起動しない。`ss -ltnp` 等で事前確認する。
+  - 特にホストに ROS2 TMS for Construction をネイティブで構築済み環境では、**`mongod` が `systemd` で常駐していて気づきにくい** ことがある。`sudo systemctl stop mongod`（必要なら `sudo systemctl disable mongod`）で停止する。停止せずに `restore-db.sh` を実行すると、ネイティブの MongoDB にシードを誤投入してしまう。
 - **`xhost +local:` は開きっぱなしにしない**: 外部ユーザーもローカル X サーバに接続できる状態になる。作業終了後は `xhost -local:` で閉じる。
 - **xrdp 等のリモートデスクトップ経由で `DISPLAY` 値がセッションごとに変わる環境**: `docker compose up` 時の `$DISPLAY` がコンテナ内に固定化される。再接続後は `docker compose down && up` するか `docker exec -u ros -e DISPLAY=$DISPLAY …` で上書きする。
 - **MongoDB へのアクセス**: `27017:27017` をホストに publish しているため、Compass 等の MongoDB クライアントから `mongodb://localhost:27017` で接続可（コンテナ内には Compass は入っていない）。

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,148 @@
+# ROS2-TMS-for-Construction — Docker 開発環境（X11 版）
+
+`main` を派生元とした Docker 開発環境。`docker/` サブディレクトリ配下だけで完結しており、既存ファイルには手を入れない。
+
+- **ベース image**: `osrf/ros:humble-desktop-full`（Ubuntu 22.04 jammy）
+- **GUI**: X11 forward（VNC なし）
+- **MongoDB**: 別サービス (`mongo:6.0`) として分離
+- **外部依存**: `docker/src.repos` で commit を固定して vcstool 管理
+
+## 前提
+
+- Ubuntu ホスト（ROS 2 humble の Tier 1 プラットフォーム要件）
+- Docker Engine + docker-compose v2
+- X サーバが稼働中（GUI を使う場合）
+
+## ワークスペース構造
+
+```
+/workspace/                          # コンテナ内
+├── src/
+│   ├── ros2_tms_for_construction/   # host repo を bind mount
+│   ├── Groot/                       # 以下 src.repos で clone（image 内）
+│   ├── tms_if_for_opera/
+│   └── opera/{common,simulator,zx200,ic120}/…
+├── build/    ← named volume `tms_build`
+├── install/  ← named volume `tms_install`
+└── log/      ← named volume `tms_log`
+```
+
+## 起動手順
+
+### 1. ビルド
+
+```bash
+cd docker
+UID=$(id -u) GID=$(id -g) docker compose build
+```
+
+`UID` / `GID` を build args で渡すのは、コンテナ内 `ros` ユーザーの UID/GID をホストと揃えて bind mount の権限不一致を防ぐため。初回は BehaviorTree.CPP / mongo-c-driver / mongo-cxx-driver などのソースビルドが走るため 20〜30 分かかる想定。
+
+### 2. X サーバーへのアクセス許可（GUIを使用するセッションごとに 1 回）
+
+```bash
+xhost +local:
+```
+
+### 3. 起動
+
+```bash
+docker compose up -d
+```
+
+初回起動時にコンテナ内で `colcon build` が自動実行される（37 packages、10 分前後）。
+
+`src.repos` / `Dockerfile` を更新したときは `docker compose down -v` で named volume ごと削除してから build → up する（`down` だけでは volume が残り古い artifact が再利用される）。
+
+### 4. MongoDB シードデータの投入（初回のみ）
+
+`demo/rostmsdb_collections.zip` を展開して `mongorestore` する:
+
+```bash
+docker compose exec tms /workspace/src/ros2_tms_for_construction/docker/restore-db.sh
+```
+
+完了すると `rostmsdb` に task 11 件・parameter 40 件ほどが投入される。スクリプト末尾でシードの `parameter` collection から `description` (string) フィールドを自動除去している（subtask 側の型不整合 workaround）。
+
+動作確認に使う `task_id=4`（zx200 掘削積込タスク）はシードに含まれているため `task_generator.py` での登録は不要。
+
+## 動作確認
+
+各ターミナル共通の前置き（sourced shell に入る）:
+
+```bash
+docker exec -it -u ros -e DISPLAY=$DISPLAY ros2_tms_dev bash
+```
+
+`-u ros` は必須（コンテナの `USER` が root のまま、entrypoint 内で `gosu` drop しているため）。
+
+### Step A. 4 ターミナル起動（順序任意）
+
+各ターミナルで前置きの `docker exec ...` を実行してから以下を起動する。
+
+| Terminal | 役割 | コマンド |
+|---|---|---|
+| 1 | Unity ↔ ROS 2 ブリッジ | `ros2 launch ros_tcp_endpoint endpoint.py` |
+| 2 | tms_if_for_opera アクションサーバ群 | `ros2 launch tms_if_for_opera tms_if_for_opera.launch.py` |
+| 3 | zx200 MoveIt2 + ros2_control + RViz | `ros2 launch zx200_bringup vehicle.launch.py use_rviz:=true command_interface_name:=velocity` |
+| 4 | task scheduler + zx200 subtask 群 + `tms_ur_button` GUI | `ros2 launch tms_ts_launch tms_ts_construction.launch.py task_id:=4` |
+
+Terminal 3 の `command_interface_name:=velocity` は Unity 側で `boom_link` / `arm_link` / `bucket_link` の Control Type を Velocity に設定する Step B と整合させるため。`use_rviz:=true` で MoveIt2 用 RViz が起動する。
+
+Terminal 3 までの起動状態で、RViz の MotionPlanning パネルから手動 Plan & Execute も可能（BT を使わない動作確認）。
+
+### Step B. Unity 側の設定（初回のみ）と再生
+
+ROS-TCP-Endpoint (Terminal 1) が listen 状態になってから Unity を再生する。Endpoint が立っていない状態で Unity を再生しても接続できない。
+
+1. Unity 起動 → 上部ツールバー **`Robotics` → `ROS Settings`** を開き、`ROS IP Address` に **ホスト (Docker を実行しているマシン) の IP**、`ROS Port` に **`10000`** を設定。`network_mode: host` でコンテナとホストの NW を共有しているため、コンテナ IP ではなくホスト IP を指す（参考: [pwri-opera/OperaSim-PhysX](https://github.com/pwri-opera/OperaSim-PhysX)）
+2. `Hierarchy` で `zx200` 選択 → `Inspector` の **`JointStatePublisher / Topic Name`** を `zx200/joint_states` に変更
+3. `zx200` 配下を展開（`base_link` → `body_link`） → **`boom_link` / `arm_link` / `bucket_link`** の `Inspector` で `Control Type Annotation / Control Type` が `Position` の場合は **`Velocity`** に変更
+4. Unity を **再生**（▶︎）→ Terminal 1 に `Connection from <Unity-IP>` のログが出れば接続成功
+
+### Step C. RViz で初期姿勢を回避（衝突回避の前処理）
+
+Terminal 3 で起動した RViz2 の MoveIt パネルを操作する。
+
+起動直後はバックホウのアームが伸び切った姿勢で、バケットが地面に接触している（バケットが**ピンク色**で表示される＝衝突状態）。この状態のまま緑ボタンを押すと BT 実行中に planning が破綻し表示が崩れるため、**先に手動で 1 回だけ姿勢を正しておく**:
+
+1. RViz の MoveIt MotionPlanning パネル → **`Joints` タブ**
+2. **`boom_joint` のスライダーを少し下げる**（角度を負方向に動かしてバケットを地面から浮かす）
+3. **`Planning` タブ → `Plan and Execute`** で実行
+4. バケットがピンク色でなくなったことを確認
+
+Terminal 4 を起動するたびに必要（停止 → 再起動でこの状態に戻る）。
+
+### Step D. `tms_ur_button` GUI の緑ボタンで BT 実行
+
+Terminal 4 起動時に `tms_ur_button` が Tkinter のウィンドウを表示する。緑ボタンを押すと task_id=4 の Behavior Tree が `task_schedular_manager` に送られ、Unity 上のバックホウが掘削動作する。
+
+1 回の実行で BT 全体が SUCCESS して終端する設計のため、**もう一度動かしたい場合は Terminal 4 を Ctrl-C → 再起動** してから Step C → 緑ボタンを押す（または BT 自体を `Repeat num_cycles=N` 構造で登録し直す。シードの `task_id=5` は task_id=4 を 4 回反復する版）。
+
+## 停止
+
+```bash
+docker compose down         # コンテナ停止（named volume は保持）
+docker compose down -v      # named volume ごと削除（DB・build キャッシュも消える）
+```
+
+## 既知の制約
+
+- ROS 2 humble の Tier 1 サポートは Ubuntu 22.04 のみ。他 OS は未サポート。
+- GPU アクセラレーションは未設定（必要なら `compose.yaml` に `deploy.resources.reservations.devices` を追加）。
+- `*moveit*` / `*nav2*` / `*tf*` をワイルドカードで apt install しているため image サイズが大きい（約 12 GB）。必要パッケージに絞るには Dockerfile を調整する。
+- **ポート衝突**: `network_mode: host` のため `27017`（MongoDB）および Terminal 1 で使う `10000`（ros_tcp_endpoint）がホストで使用中だと起動しない。`ss -ltnp` 等で事前確認する。
+- **`xhost +local:` は開きっぱなしにしない**: 外部ユーザーもローカル X サーバに接続できる状態になる。作業終了後は `xhost -local:` で閉じる。
+- **xrdp 等のリモートデスクトップ経由で `DISPLAY` 値がセッションごとに変わる環境**: `docker compose up` 時の `$DISPLAY` がコンテナ内に固定化される。再接続後は `docker compose down && up` するか `docker exec -u ros -e DISPLAY=$DISPLAY …` で上書きする。
+- **MongoDB へのアクセス**: `27017:27017` をホストに publish しているため、Compass 等の MongoDB クライアントから `mongodb://localhost:27017` で接続可（コンテナ内には Compass は入っていない）。
+
+## `docker/` 配下ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `Dockerfile` | ベース image + ROS 2 依存 + source build で BehaviorTree.CPP / mongocxx / mongo-c-driver + `vcs import` |
+| `Dockerfile.dockerignore` | このビルド専用の ignore ファイル（BuildKit の per-Dockerfile ignore）。allowlist 形式でビルドコンテキストを絞る |
+| `compose.yaml` | `mongodb`（`mongo:6.0`）と `tms` の 2 サービス、named volume、X11 forward、`network_mode: host` |
+| `entrypoint.sh` | root で named volume 所有権を修正後、`gosu` で `ros` に drop。成功 sentinel で初回 `colcon build` を一度だけ実行 |
+| `restore-db.sh` | `demo/rostmsdb_collections.zip` を展開して `mongorestore`、その後 `parameter` collection から `description` (string) フィールドを除去（subtask が数値型のみ対応のため） |
+| `src.repos` | vcstool 管理。外部 repo を 40 桁 full commit SHA で pin（コメントで元ブランチと日付を保持） |

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,46 @@
+name: ros2-tms-for-construction
+
+services:
+  mongodb:
+    image: mongo:6.0
+    container_name: ros2_tms_mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+  tms:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        USER_UID: ${UID:-1000}
+        USER_GID: ${GID:-1000}
+    image: ros2_tms_for_construction:dev
+    container_name: ros2_tms_dev
+    network_mode: host
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+      - MONGO_HOST=localhost
+      - MONGO_PORT=27017
+      - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      - ${XAUTHORITY:-${HOME}/.Xauthority}:/home/ros/.Xauthority:ro
+      - ../:/workspace/src/ros2_tms_for_construction
+      - tms_build:/workspace/build
+      - tms_install:/workspace/install
+      - tms_log:/workspace/log
+    depends_on:
+      - mongodb
+    stdin_open: true
+    tty: true
+
+volumes:
+  mongodb_data:
+  tms_build:
+  tms_install:
+  tms_log:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -20,6 +20,7 @@ services:
     image: ros2_tms_for_construction:dev
     container_name: ros2_tms_dev
     network_mode: host
+    shm_size: 1g
     environment:
       - DISPLAY=${DISPLAY}
       - QT_X11_NO_MITSHM=1

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# ros2_tms_for_construction container entrypoint.
+#
+# First phase (as root):
+#   - Fix ownership of named volumes (Docker creates them as root on first
+#     mount; ros user cannot write otherwise).
+#   - Re-exec self as the unprivileged `ros` user via gosu.
+#
+# Second phase (as ros):
+#   - Source ROS 2 + workspace install.
+#   - On first run (no success sentinel), run `colcon build --symlink-install`
+#     and touch the sentinel only on success. This avoids treating a
+#     half-built install/ as "already built" on the next start.
+#   - exec the command (defaults to bash via Dockerfile CMD).
+
+set -e
+
+if [ "$(id -u)" = "0" ]; then
+    for d in build install log; do
+        if [ -d "/workspace/$d" ] && [ "$(stat -c '%U' "/workspace/$d")" != "ros" ]; then
+            chown -R ros:ros "/workspace/$d"
+        fi
+    done
+    exec gosu ros "$0" "$@"
+fi
+
+source /opt/ros/humble/setup.bash
+export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
+
+cd /workspace
+
+SENTINEL=/workspace/install/.colcon_build_succeeded
+
+if [ ! -f "${SENTINEL}" ]; then
+    echo "[entrypoint] Initial colcon build (no success sentinel at ${SENTINEL})"
+    if colcon build --symlink-install; then
+        touch "${SENTINEL}"
+    else
+        echo "[entrypoint] colcon build failed. Dropping into shell for debugging." >&2
+        exec bash
+    fi
+fi
+
+if [ -f /workspace/install/setup.bash ]; then
+    source /workspace/install/setup.bash
+fi
+
+exec "$@"

--- a/docker/launch/bringup.launch.yaml
+++ b/docker/launch/bringup.launch.yaml
@@ -1,0 +1,44 @@
+launch:
+  - arg:
+      name: task_id
+      default: "4"
+      description: "Task ID executed by tms_ur_button when the green button is pressed"
+  - arg:
+      name: command_interface_name
+      default: "velocity"
+      description: "ros2_control command interface (velocity / position / effort)"
+  - arg:
+      name: use_rviz
+      default: "true"
+      description: "Launch RViz alongside zx200_bringup"
+  - arg:
+      name: tms_if_delay
+      default: "5.0"
+      description: "Seconds to wait before launching tms_if_for_opera (avoids SRDF subscribe timeout). Increase on slower hosts."
+  - arg:
+      name: tms_ts_delay
+      default: "10.0"
+      description: "Seconds to wait before launching tms_ts_construction (must be > tms_if_delay). Increase on slower hosts."
+
+  - include:
+      file: $(find-pkg-share zx200_bringup)/launch/vehicle.launch.py
+      arg:
+        - name: command_interface_name
+          value: $(var command_interface_name)
+        - name: use_rviz
+          value: $(var use_rviz)
+
+  - timer:
+      period: $(var tms_if_delay)
+      children:
+        - include:
+            file: $(find-pkg-share tms_if_for_opera)/launch/tms_if_for_opera.launch.py
+
+  - timer:
+      period: $(var tms_ts_delay)
+      children:
+        - include:
+            file: $(find-pkg-share tms_ts_launch)/launch/tms_ts_construction.launch.py
+            arg:
+              - name: task_id
+                value: $(var task_id)

--- a/docker/restore-db.sh
+++ b/docker/restore-db.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Restore the seed MongoDB collections shipped under demo/rostmsdb_collections.zip
+# into the running `mongodb` service. Run this once after `docker compose up -d`.
+#
+# Usage (from host):
+#   docker compose -f docker/compose.yaml exec tms /workspace/src/ros2_tms_for_construction/docker/restore-db.sh
+#
+# Writes to the bind-mounted demo/ directory (extracts rostmsdb_collections.zip
+# into demo/dump/), so we drop to the `ros` user if invoked as root. Otherwise
+# demo/dump would end up root-owned on the host.
+
+set -euo pipefail
+
+if [ "$(id -u)" = "0" ]; then
+    exec gosu ros "$0" "$@"
+fi
+
+DEMO_DIR="/workspace/src/ros2_tms_for_construction/demo"
+ZIP_PATH="${DEMO_DIR}/rostmsdb_collections.zip"
+DUMP_DIR="${DEMO_DIR}/dump"
+
+MONGO_HOST="${MONGO_HOST:-localhost}"
+MONGO_PORT="${MONGO_PORT:-27017}"
+
+if [ ! -d "${DUMP_DIR}" ]; then
+    if [ ! -f "${ZIP_PATH}" ]; then
+        echo "[restore-db] ERROR: ${ZIP_PATH} not found" >&2
+        exit 1
+    fi
+    echo "[restore-db] Extracting ${ZIP_PATH}"
+    (cd "${DEMO_DIR}" && unzip -o "$(basename "${ZIP_PATH}")")
+fi
+
+echo "[restore-db] mongorestore --drop --host ${MONGO_HOST} --port ${MONGO_PORT} ${DUMP_DIR}"
+mongorestore --drop --host "${MONGO_HOST}" --port "${MONGO_PORT}" "${DUMP_DIR}"
+
+# The shipped seed embeds a `description` (string) field in many `parameter`
+# records (initial_pose, target_excavate_pose, ...). The current
+# `subtask_zx200_*` implementations iterate over each key and only handle
+# numeric types (int32 / int64 / double); the string `description` triggers a
+# TypeError and the BT call stalls before sending the goal.
+# Strip the field as a post-restore fix-up so task_id=4 etc. work out of the
+# box without manual MongoDB editing. Drop this block once the seed (or the
+# subtask side) treats `description` properly.
+echo "[restore-db] Stripping 'description' from parameter records (workaround for subtask type-handling)"
+python3 - "${MONGO_HOST}" "${MONGO_PORT}" <<'PY'
+import sys
+from pymongo import MongoClient
+
+host, port = sys.argv[1], int(sys.argv[2])
+client = MongoClient(host, port)
+result = client["rostmsdb"]["parameter"].update_many(
+    {"description": {"$exists": True}},
+    {"$unset": {"description": ""}},
+)
+print(f"[restore-db]   modified {result.modified_count} parameter records")
+PY
+
+echo "[restore-db] Done."

--- a/docker/src.repos
+++ b/docker/src.repos
@@ -1,0 +1,33 @@
+# External ROS 2 packages fetched by vcstool inside the Docker image.
+# Pinned to full 40-character commit SHAs for reproducibility. Comments record
+# the branch name and date at the time of pinning so the intent is recoverable
+# when refreshing these pins later.
+repositories:
+  Groot:
+    type: git
+    url: https://github.com/BehaviorTree/Groot.git
+    version: 70973d004365f16d47a8c7bd9c5d84fa0bb9d05d  # master @ 2025-02-28
+  tms_if_for_opera:
+    type: git
+    url: https://github.com/irvs/tms_if_for_opera.git
+    version: 45bb2ff559eaca6d1e2fcc45f8f9200593451193  # main @ 2026-04-28 (merge of #14: package.xml <depend> fix)
+  opera/common/com3_ros:
+    type: git
+    url: https://github.com/pwri-opera/com3_ros.git
+    version: 2b78c3016649f9b1aea902d6d6a82eeec941eb91  # main @ 2025-07-09
+  opera/common/gnss_localizer_ros2:
+    type: git
+    url: https://github.com/pwri-opera/gnss_localizer_ros2.git
+    version: 7ea044d7254d85c936cbb64b2e73a71330fea6d9  # main @ 2025-07-25
+  opera/simulator/ROS-TCP-Endpoint:
+    type: git
+    url: https://github.com/Unity-Technologies/ROS-TCP-Endpoint.git
+    version: 54c1a64b6d5ef6ffa0a0431570bb74329b79b15b  # main-ros2 @ 2022-02-01 (Release 0.7.0 ROS2)
+  opera/zx200/zx200_ros2:
+    type: git
+    url: https://github.com/pwri-opera/zx200_ros2.git
+    version: d8c8453850708327d99fccf81c0c16bb4ae90c2e  # main @ 2026-04-17
+  opera/ic120/ic120_ros2:
+    type: git
+    url: https://github.com/pwri-opera/ic120_ros2.git
+    version: e58663ec8b7121358a0fd76d0c8a80180e193eb6  # main @ 2025-05-09


### PR DESCRIPTION
## 概要

`main` の派生として、自己完結した X11 ベースの Docker 開発環境を新しい `docker/` サブディレクトリ配下に追加します。既存ファイルは一切変更していません。

新規 contributor が `ros2_tms_for_construction` を clone してから、Ubuntu 22.04 / 24.04 ホスト上で `task_id=4`（シードに含まれる zx200 掘削積込タスク）の **2 ターミナル動作確認**に到達するまでを、ROS 2 humble / BehaviorTree.CPP / mongocxx / MongoDB / OPERA 関連 / Unity ROS-TCP-Endpoint を手動でインストールせずに完結できるようにすることが目的です。再現性のため `docker/src.repos` で全外部依存を commit SHA で pin しています。

意図的に「追加のみ」の構成にしています: 既存の `docker-model` ブランチおよびリポジトリルートの `DockerFile`（VNC + MongoDB 同居型）はそのまま残しており、引き続き選択肢として共存します。

## 動作確認済の組合せ

**Ubuntu 22.04 LTS / 24.04 LTS ホスト（いずれも X11 セッション）で動作確認済**。各バージョンは `docker/src.repos` で pin しています:

| コンポーネント | リポジトリ | ブランチ | コミット |
|---|---|---|---|
| `ros2_tms_for_construction` | この PR のブランチ | `main` | PR open 時の HEAD |
| `tms_if_for_opera` | irvs/tms_if_for_opera | `main` | `45bb2ff5` |
| `zx200_ros2` (zx200_*) | pwri-opera/zx200_ros2 | `main` | `d8c84538` |
| `com3_ros` (com3_msgs) | pwri-opera/com3_ros | `main` | `2b78c301` |
| `gnss_localizer_ros2` | pwri-opera/gnss_localizer_ros2 | `main` | `7ea044d7` |
| `ic120_ros2` | pwri-opera/ic120_ros2 | `main` | `e58663ec` |
| `Groot` | BehaviorTree/Groot | `master` | `70973d00` |
| `ROS-TCP-Endpoint` | Unity-Technologies/ROS-TCP-Endpoint | `main-ros2` | `54c1a64b` |

エンドツーエンド確認（Ubuntu 22.04 ホスト）: `task_id=4` の 6 サブタスク（`change_pose` → `excavate_simple` → `change_pose` × 2 → `release_simple`）が、Unity-Technologies の ROS-TCP-Endpoint 経由で [pwri-opera/OperaSim-PhysX](https://github.com/pwri-opera/OperaSim-PhysX) と接続した状態で完走することを確認しています。

Ubuntu 24.04 ホストでは `docker compose build` (image 8.24 GB) → 初回 `colcon build` (37 packages, 0 failures) → MongoDB シード投入 (727 documents) → `bringup.launch.yaml` 起動による 3 launch 連鎖起動 + RViz の X11 forward 表示までを確認しています (`compose.yaml` の `${XAUTHORITY:-${HOME}/.Xauthority}` フォールバックが効くため、追加設定なしで動作)。

## レビューでの確認方法

1. ネイティブの環境を構築済みの場合には、ネイティブでビルドしたros2_tms_for_constructionに関わるROSノードをすべて落としておく。`mongod` が `systemd` で常駐している場合には `sudo systemctl stop mongod`（必要なら `sudo systemctl disable mongod`）で停止する。
2. このブランチを Ubuntu 22.04 / 24.04 ホスト（Docker Engine + docker-compose v2 + X サーバが稼働中）に checkout
3. image をビルド（初回は BehaviorTree.CPP / mongo-c-driver / mongo-cxx-driver のソースビルドを含むため約 10〜20 分）:
   ```bash
   cd docker
   UID=$(id -u) GID=$(id -g) docker compose build
   ```
4. ローカル X クライアントへのアクセスを許可し、コンテナを起動:
   ```bash
   xhost +local:
   docker compose up -d
   ```
   `tms` コンテナの entrypoint が初回起動時に `colcon build --symlink-install` を自動実行します（37 packages、約 2〜10 分）
5. MongoDB シードを 1 度だけ投入:
   ```bash
   docker compose exec tms /workspace/src/ros2_tms_for_construction/docker/restore-db.sh
   ```
   `task_id=4` はシードに含まれているため `task_generator.py` の実行は不要です
6. **2 ターミナル**を開いて起動:
   - **Terminal 1** (Unity ↔ ROS 2 ブリッジ):
     ```bash
     docker exec -it -u ros -e DISPLAY=$DISPLAY ros2_tms_dev bash
     ros2 launch ros_tcp_endpoint endpoint.py
     ```
   - Unity (OperaSim-PhysX) を起動して `Robotics → ROS Settings` を `docker/README.md` の Step B どおりに設定し、**再生ボタンを押下**
   - **Terminal 2** (3 launch 連鎖):
     ```bash
     docker exec -it -u ros -e DISPLAY=$DISPLAY ros2_tms_dev bash
     ros2 launch /workspace/src/ros2_tms_for_construction/docker/launch/bringup.launch.yaml
     ```
   - Terminal 2 起動から `tms_ts_delay` 秒（既定 10）経過後、`docker/README.md` の Step C で RViz の初期姿勢を解消、Step D で `tms_ur_button` の緑ボタンを押下

詳細な手順は [`docker/README.md`](docker/README.md) を参照してください。

## 設計判断

- **X11 forward、VNC なし。** ROS 2 humble の Tier 1 サポートは Ubuntu 22.04 のみであり、Unity ROS-TCP-Endpoint も実質 Linux 前提のため、クロスプラットフォーム GUI の複雑さは意図的に切り捨てています。`docker-model` ブランチの noVNC + supervisord 構成と比べてメンテナンス対象が小さくなります
- **Compose による 2 サービス構成 (`tms` + `mongodb`)。** MongoDB はアプリケーションコンテナと同居させず、専用の `mongo:6.0` サービスに分離しました。バックアップ・スケール・バージョンアップが独立して行え、既存の `tms_db_manager` コードが想定する本番デプロイ形態にも合います
- **`tms` サービスでの `network_mode: host`。** ROS 2 DDS のマルチキャストや Unity ROS-TCP-Endpoint のポート `10000` をホスト側に直接出しつつ、`localhost:27017` で MongoDB に接続できるようにするためです
- **`tms` サービスでの `shm_size: 1g`。** Fast DDS の SHM transport が `/dev/shm/fastrtps_*` に lock ファイルを多数作るため、Docker default (64 MB) では `tms_ts_construction` の 50+ ノード同時起動 + 反復実行で枯渇し `Failed init_port ... open_and_lock_file` が発生します。1 GB に拡張して余裕を確保します
- **`docker/launch/bringup.launch.yaml` による 3 launch 連鎖起動 (4 → 2 ターミナル化)。** `zx200_bringup` → `tms_if_for_opera` → `tms_ts_construction` を timer (`tms_if_delay=5.0` / `tms_ts_delay=10.0` 既定) で連鎖起動します。時間差は `zx200_bringup` が `robot_description_semantic` (SRDF) を publish する前に `tms_if_for_opera` 側 MoveGroupInterface が subscribe すると 10 秒 timeout で FATAL 終了するため。低性能ホストでは `tms_if_delay` / `tms_ts_delay` arg で実行時に増やせます。`ros_tcp_endpoint` を分離している (Terminal 1) のは、Unity の `JointStatePublisher` が `/zx200/joint_states` を流す前に `zx200_bringup` の `ros2_control` を起動するとコントローラ初期化が不安定になるため
- **`docker/src.repos` での再現可能な外部ソース管理。** 各外部リポジトリを 40 桁の commit SHA で pin し、コメントで元のブランチ名と commit 日付を記録しています。実際に `vcs import` で使われるのは SHA です
- **`docker/Dockerfile.dockerignore` による per-Dockerfile ignore。** `compose.yaml` で `build.context: ..`（リポジトリルート）にしているため、`docker/.dockerignore` を置いても効きません。allowlist 形式にしているため、`demo/`（約 270 MB）や `.git/`（約 210 MB）を毎回 BuildKit に転送せずに、build context を数 KB に抑えています
- **Root エントリーポイント → `gosu` で `ros` ユーザーへ drop。** Docker のデフォルトでは初回マウント時 named volume の所有者が root になるため、entrypoint がまず chown を行い、その後で権限を落としてからユーザーコマンドを `exec` します
- **ビルド成功 sentinel `/workspace/install/.colcon_build_succeeded`。** entrypoint は初回 `colcon build` が成功した場合のみ touch します。途中で失敗した場合は sentinel が作られないため次回の `up` で自動的に再試行され、半端な install を黙って source することを防ぎます
- **`docker/restore-db.sh` で古い `description` フィールドを除去。** シードの `parameter` collection に string 型の `description` フィールドが含まれていますが、現行の `subtask_zx200_*` 実装は parameter のキーを数値型として読み込むため、この string で停止します。`mongorestore` 後に `pymongo` 経由で `$unset` する処理を入れているため、`task_id=4` がそのまま動きます。シード側 (zip) または subtask 側で `description` を扱えるようになれば、この post-fix は撤去できます

## 依存

`irvs/tms_if_for_opera` 側で先にマージいただいた、`CMakeLists.txt` で `find_package` されているが `package.xml` の `<depend>` に未記載だったエントリの追加が前提になっています:

- #12 → `develop/for_develop_ts`
- #13 → `feature/primitive`
- #14 → `main` ← 本 PR の `tms_if_for_opera` の pin (`45bb2ff5`) はこの commit より進めています

その他の上流リポジトリへの変更は不要です。

## 既知の制約

- ROS 2 humble の Tier 1 サポートは Ubuntu 22.04 のみ
- GPU はデフォルトでは未設定
- `*moveit*` / `*nav2*` / `*tf*` のワイルドカード apt install のため image サイズが約 8〜12 GB
- `network_mode: host` のため、`27017`（MongoDB）と `10000`（ros_tcp_endpoint）がホストで使用中だと起動しない
- `xhost +local:` は作業終了時に `xhost -local:` で閉じることを推奨
- `DISPLAY` は `docker compose up` 時の値が使われるため、リモートデスクトップ等で `$DISPLAY` が変わった場合は `compose down/up` するか `docker exec -e DISPLAY=$DISPLAY …` で上書きが必要
- MongoDB の `27017:27017` をホストに publish しているため、Compass 等から `mongodb://localhost:27017` で接続可能

### 本 PR のスコープ外

- **Wayland セッション** (Ubuntu 24.04 の物理コンソール直ログイン時など)。Xwayland 経由で動作する見込みだが本 PR では未検証。動かない場合は `QT_QPA_PLATFORM=xcb` や `xhost si:localuser:$USER` 等の追加設定が必要となる可能性
- **NVIDIA Container Toolkit による GPU passthrough**。`compose.yaml` に `deploy.resources.reservations.devices` 未設定、CPU レンダリングのみで検証
- **Unity (OperaSim-PhysX) 連携 + `task_id=4` の完走** は Ubuntu 22.04 ホストでのみ確認済。24.04 では Terminal 1〜2 (= 全ノード起動 + RViz 表示) までで、Unity 再生 + 緑ボタン押下による完走は未実施

## ファイル一覧

`docker/` 配下のみ、新規 8 ファイル。サブディレクトリ外への変更はありません。

| ファイル | 役割 |
|---|---|
| `Dockerfile` | `osrf/ros:humble-desktop-full` ベース、BehaviorTree.CPP / mongo-c-driver / mongo-cxx-driver のソースビルド、vcstool import、`gosu` ベースの権限 drop |
| `Dockerfile.dockerignore` | BuildKit の per-Dockerfile ignore（allowlist 形式） |
| `compose.yaml` | `mongodb` + `tms` の 2 サービス、named volume、X11 forward、`network_mode: host`、`tms` には Fast DDS の SHM lock 用に `shm_size: 1g` を割当 |
| `entrypoint.sh` | volume の所有権修正、`gosu ros` への drop、sentinel ガード付きの初回 `colcon build` |
| `restore-db.sh` | `demo/rostmsdb_collections.zip` の展開、`mongorestore`、post-fix での `description` 除去 |
| `src.repos` | 40 桁 SHA で pin した vcstool マニフェスト |
| `README.md` | セットアップ、2 ターミナル運用、既知の制約 |
| `launch/bringup.launch.yaml` | Terminal 2 用。`zx200_bringup` → `tms_if_for_opera` → `tms_ts_construction` の 3 launch を timer 連鎖起動する YAML launch（`tms_if_delay` / `tms_ts_delay` arg で待ち時間を調整可能） |
