### PR TITLE
docker: RMW を Cyclone DDS デフォルト化（Fast DDS 切替対応）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         nlohmann-json3-dev rapidjson-dev \
         qtbase5-dev libqt5svg5-dev libdw-dev \
         ros-humble-robot-localization \
+        ros-humble-rmw-cyclonedds-cpp \
     && apt-get install -y --no-install-recommends \
         'ros-humble-*moveit*' \
         'ros-humble-*nav2*' \

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,7 +48,7 @@ docker compose down         # コンテナ停止（named volume は保持）
 
 ## ドキュメント
 
-- [docs/setup.md](docs/setup.md) — 前提・ワークスペース構造・起動手順（詳細）
+- [docs/setup.md](docs/setup.md) — 前提・ワークスペース構造・起動手順（詳細）・RMW(DDS)切替
 - [docs/usage.md](docs/usage.md) — `task_id=4` 完走手順（Terminal 1 / 2、Unity 設定、RViz 操作、緑ボタン）
 - [docs/known-issues.md](docs/known-issues.md) — 既知の制約・トラブルシュート
 
@@ -58,7 +58,8 @@ docker compose down         # コンテナ停止（named volume は保持）
 |---|---|
 | `Dockerfile` | ベース image + ROS 2 依存 + source build (BehaviorTree.CPP / mongocxx / mongo-c-driver) + `vcs import` |
 | `Dockerfile.dockerignore` | このビルド専用の ignore ファイル（BuildKit の per-Dockerfile ignore）。allowlist 形式でビルドコンテキストを絞る |
-| `compose.yaml` | `mongodb`（`mongo:6.0`）と `tms` の 2 サービス、named volume、X11 forward、`network_mode: host`、`tms` には Fast DDS の SHM lock 用に `shm_size: 1g` を割当 |
+| `compose.yaml` | `mongodb`（`mongo:6.0`）と `tms` の 2 サービス、named volume、X11 forward、`network_mode: host`、`tms` には Fast DDS 使用時の SHM lock 用に `shm_size: 1g` を割当。`RMW_IMPLEMENTATION` で Cyclone DDS(既定)/Fast DDS、`CYCLONEDDS_URI` で discovery profile を切替 |
+| `cyclonedds.xml` | Cyclone DDS の discovery profile（loopback-only + `DontRoute`）。compose の `CYCLONEDDS_URI` 既定がこれを指す。詳細は [docs/setup.md](docs/setup.md) |
 | `src.repos` | vcstool 管理。外部 repo を 40 桁 full commit SHA で pin（コメントで元ブランチと日付を保持） |
 | `launch/bringup.launch.yaml` | Terminal 2 用。`zx200_bringup` → `tms_if_for_opera` → `tms_ts_construction` の 3 launch を timer 連鎖起動する YAML launch |
 | `scripts/entrypoint.sh` | container 起動時に root で named volume 所有権を修正後、`gosu` で `ros` に drop、成功 sentinel で初回 `colcon build` を一度だけ実行 |

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -27,7 +27,10 @@ services:
       - MONGO_HOST=localhost
       - MONGO_PORT=27017
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID:-0}
-      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION:-rmw_cyclonedds_cpp}
+      # Cyclone DDS の discovery profile。既定で同梱 docker/cyclonedds.xml (loopback-only + DontRoute) を適用し単一ホスト内に隔離。
+      # 複数マシンで discover したい場合は CYCLONEDDS_URI= で空にして built-in default (host NIC の multicast) に戻す。
+      - CYCLONEDDS_URI=${CYCLONEDDS_URI:-file:///workspace/src/ros2_tms_for_construction/docker/cyclonedds.xml}
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       - ${XAUTHORITY:-${HOME}/.Xauthority}:/home/ros/.Xauthority:ro

--- a/docker/cyclonedds.xml
+++ b/docker/cyclonedds.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS>
+ <Domain>
+     <General>
+         <Interfaces>
+            <NetworkInterface address="127.0.0.1" multicast="true"/> 
+         </Interfaces>
+         <DontRoute>true</DontRoute>
+     </General>
+ </Domain>
+</CycloneDDS>

--- a/docker/docs/setup.md
+++ b/docker/docs/setup.md
@@ -53,6 +53,27 @@ docker compose up -d    # sentinel があるので colcon build は skip、秒�
 
 `src.repos` / `Dockerfile` を更新したときは `docker compose down -v` で named volume ごと削除してから build → up する（`down` だけでは volume が残り古い artifact が再利用される）。
 
+## RMW (DDS) の選択と切替
+
+デフォルトは Cyclone DDS (`rmw_cyclonedds_cpp`)。両 RMW 実装は image に同梱済み (`ros-humble-rmw-{fastrtps,cyclonedds}-cpp`) で、ホスト側に DDS をインストールする必要はない（RMW プラグインはコンテナ内 ROS 2 プロセスに linked-in される）。
+
+| RMW | 起動コマンド | 備考 |
+|---|---|---|
+| Cyclone DDS (default) | `docker compose up -d` | 同梱 `cyclonedds.xml` (loopback-only + `DontRoute`) を既定適用し単一ホスト内に隔離 |
+| Fast DDS | `RMW_IMPLEMENTATION=rmw_fastrtps_cpp docker compose up -d` | `shm_size: 1g` で共有メモリ転送を有効化済み |
+
+### discovery のスコープ
+
+既定の `cyclonedds.xml` は loopback (`127.0.0.1`) のみで discovery するため、**同一ホスト上の他 ROS 2 プロセス（`network_mode: host` の別コンテナ含む）とだけ discover し、LAN 上の別マシンとは繋がらない**。
+
+- 複数マシンで discover したい: `CYCLONEDDS_URI=` で空にして built-in default (host NIC の multicast) に戻す。
+- 独自設定を使う: `docker/cyclonedds.xml` を直接編集するか、`CYCLONEDDS_URI=file:///path/to/your.xml` で別ファイルを指す（compose.yaml で pass-through 済み）。
+- ホスト内でさらに分離したい: `ROS_DOMAIN_ID` を変更する。
+
+### Zenoh で複数現場を繋ぐ場合
+
+WAN / NAT 越し・複数現場を繋ぎたい場合は、`rmw_zenoh` をコンテナに入れるのではなく、ホストで [`zenoh-bridge-ros2dds`](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) を起動して DDS を Zenoh network に bridge する構成を推奨する（コンテナ側は DDS のままで OK）。`rmw_zenoh` 同梱の `rmw_zenohd` は rmw_zenoh ノード専用 router で DDS との bridge を持たないため、この用途には使えない。
+
 ## 次のステップ
 
 - 動作確認 (`task_id=4` 完走): [usage.md](usage.md)


### PR DESCRIPTION
`docker/` 開発環境の RMW (DDS) を **デフォルト Cyclone DDS** に変更し、`RMW_IMPLEMENTATION` 環境変数で Fast DDS にも切り替えられるようにします。

> [!NOTE]
> デフォルトを Fast DDS → Cyclone DDS に変更します。従来の Fast DDS 挙動は `RMW_IMPLEMENTATION=rmw_fastrtps_cpp` で再現できます。

## 変更内容

- **Dockerfile**: `ros-humble-rmw-cyclonedds-cpp` を追加（両 RMW を image に同梱。ホスト側 DDS インストール不要、RMW プラグインはコンテナ内 ROS 2 プロセスに linked-in）
- **compose.yaml**: `RMW_IMPLEMENTATION` 既定を `rmw_cyclonedds_cpp` に変更。`CYCLONEDDS_URI` 既定を同梱 `cyclonedds.xml` に配線（pass-through なので空にすれば built-in default に戻る）
- **cyclonedds.xml**（新規）: loopback-only + `DontRoute` の discovery profile。ROS グラフを単一ホスト内に隔離し、LAN 全体への multicast 漏れを防ぐ
- **docs/setup.md**: 「RMW (DDS) の選択と切替」節を追加（切替表・discovery スコープ・Zenoh 方針）
- **README**: 配下ファイル表に `cyclonedds.xml` と RMW 切替を反映

## 使い方

| RMW | 起動コマンド | discovery |
|---|---|---|
| Cyclone DDS (default) | `docker compose up -d` | 同梱 `cyclonedds.xml` で loopback-only（単一ホスト内に隔離） |
| Fast DDS | `RMW_IMPLEMENTATION=rmw_fastrtps_cpp docker compose up -d` | `shm_size: 1g` で SHM 転送 |

複数マシンで discover したい場合は `CYCLONEDDS_URI=` を空にして built-in default（host NIC の multicast）に戻すか、自前の XML を `CYCLONEDDS_URI=file://...` で渡します。

## Zenoh について

当初は `rmw_zenoh` + `zenoh-router` service も含めていましたが、

- `rmw_zenoh` 同梱の `rmw_zenohd` は rmw_zenoh ノード専用 router で、DDS との bridge を持たない
- NAT 越しのような Zenoh の主用途には [`zenoh-bridge-ros2dds`](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) をホストで立てて DDS を bridge する構成が適切（コンテナ側は DDS のまま）

という理由から、本 PR では Cyclone DDS 切替に絞り、Zenoh はコンテナに入れず `docs/setup.md` に host bridge 方針を注記するに留めています。
